### PR TITLE
fix notation mistake in Jupyter Notebook

### DIFF
--- a/hw4_extra.ipynb
+++ b/hw4_extra.ipynb
@@ -209,7 +209,7 @@
     "\n",
     "<p style=\"text-align: center;\">$X' = X \\; W_o$</p>\n",
     "\n",
-    "Your goal in this part is to return $X$ in the `self.forward` call of `AttentionLayer`. For debugging, you may capture the `probs` variable returned by the inner `MultiHeadAttention` module and store it in an attribute such as `self.probs` of the attention layer.\n",
+    "Your goal in this part is to return $X'$ in the `self.forward` call of `AttentionLayer`. For debugging, you may capture the `probs` variable returned by the inner `MultiHeadAttention` module and store it in an attribute such as `self.probs` of the attention layer.\n",
     "\n",
     "Once finished, you may test your layer with the following test cases."
    ]


### PR DESCRIPTION
In `Part 2 Implementing the Self-Attention Layer with trainable parameters` of the notebook, the value returned from the `self.forward` call of `AttentionLayer` should be `X'`(after output projection is applied) instead of `X`