### PR TITLE
Added API Key env variable and clarifying description to create_causal_mask

### DIFF
--- a/hw4_extra.ipynb
+++ b/hw4_extra.ipynb
@@ -39,6 +39,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6a1d9d3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# REQUIRED FOR MUGRADE\n",
+    "MY_API_KEY = \"<FILL YOUR API KEY HERE>\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5c9fb467",
    "metadata": {},
    "outputs": [],
@@ -159,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 -m mugrade submit \"YOUR_KEY_HERE\" \"hw4extra\" -k \"attention_activation\""
+    "!python3 -m mugrade submit \"$MY_API_KEY\" \"hw4extra\" -k \"attention_activation\""
    ]
   },
   {
@@ -231,7 +242,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 -m mugrade submit \"YOUR_KEY_HERE\" \"hw4extra\" -k \"attention_layer\""
+    "!python3 -m mugrade submit \"$MY_API_KEY\" \"hw4extra\" -k \"attention_layer\""
    ]
   },
   {
@@ -274,7 +285,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 -m mugrade submit \"YOUR_KEY_HERE\" \"hw4extra\" -k \"transformer_layer\""
+    "!python3 -m mugrade submit \"$MY_API_KEY\" \"hw4extra\" -k \"transformer_layer\""
    ]
   },
   {
@@ -314,7 +325,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python3 -m mugrade submit \"YOUR_KEY_HERE\" \"hw4extra\" -k \"transformer_model\""
+    "!python3 -m mugrade submit \"$MY_API_KEY\" \"hw4extra\" -k \"transformer_model\""
    ]
   },
   {

--- a/python/needle/nn/nn_transformer.py
+++ b/python/needle/nn/nn_transformer.py
@@ -40,6 +40,7 @@ class MultiHeadAttention(Module):
     def create_causal_mask(self, i, j, device):
         """
         return a triangular causal mask.
+        Input: i, j: the shape of the mask to be created
         """
         mask = -np.finfo(np.float32).max * np.triu(
             np.ones((1, 1, i, j), dtype=np.float32), j - i + 1)


### PR DESCRIPTION
Changes:
- Modified hw4_extra.ipynb to allow students to put their API key in an env variable instead of having to copy paste it each time for the submission of each question.
- Clarifying description on what i and j are in create_causal_mask